### PR TITLE
Fix turbo-rails yank 7.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
       activerecord (>= 5)
     thor (1.1.0)
     tilt (2.0.10)
-    turbo-rails (7.1.1)
+    turbo-rails (0.8.3)
       rails (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
The 7.1.1 version was tagged by mistake, it has been yanked and reverted back to the 0.8.X
Also see: https://github.com/hotwired/turbo-rails/commit/31e19cb4b781d186bc31edaa4035b2e13a19fc3c