### PR TITLE
Strong migrations defaults

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@
 require_relative "config/application"
 
 Rails.application.load_tasks
+
+task "db:schema:dump": "strong_migrations:alphabetize_columns"

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,10 @@ require_relative "config/application"
 Rails.application.load_tasks
 
 task "db:schema:dump": "strong_migrations:alphabetize_columns"
+
+task :faster_migrations do
+  ActiveRecord::Base.dump_schema_after_migration = Rails.env.development? &&
+    `git status db/migrate/ --porcelain`.present?
+end
+
+task "db:migrate": "faster_migrations"

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,26 @@
+# Mark existing migrations as safe
+# StrongMigrations.start_after = 20211022082946
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Set the version of the production database
+# so the right checks are run in development
+# StrongMigrations.target_version = 10
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end
+
+# Make some operations safe by default
+# See https://github.com/ankane/strong_migrations#safe-by-default
+# StrongMigrations.safe_by_default = true


### PR DESCRIPTION
Add default initializer for strong migrations and update `db:migrate` to sort the columns in `schema.rb`. We now also only dump the `schema.rb` if there are updates on the migrations.