### PR TITLE
Skip CodeCoverage push for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,8 @@ jobs:
           bin/rails db:test:prepare
           bin/rake
 
-      # - name: Publish code coverage
-      #   run: |
-      #     export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
-      #     ./cc-test-reporter after-build -r ${{secrets.CC_TEST_REPORTER_ID}}
+      - name: Publish code coverage
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        run: |
+          export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
+          ./cc-test-reporter after-build -r ${{secrets.CC_TEST_REPORTER_ID}}


### PR DESCRIPTION
Dependabot PRs do not have access to the repo secrets, we
don't actually have to push the coverage for these PR's to
begin with. This change skips pushing to code climate if the
author is dependabot.