### PR TITLE
Bump nokogiri to ">= 1.13.9"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem "image_processing", ">= 1.2"
 gem "strong_migrations"
 gem "sidekiq"
 
+gem "nokogiri", ">= 1.13.9"
+
 group :development, :test do
   # Start debugger with binding.b [https://github.com/ruby/debug]
   gem "debug", ">= 1.0.0", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,13 +175,13 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.8-aarch64-linux)
+    nokogiri (1.13.9-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.13.8-arm64-darwin)
+    nokogiri (1.13.9-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-darwin)
+    nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-linux)
+    nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.2.1)
@@ -336,6 +336,7 @@ DEPENDENCIES
   jbuilder (~> 2.11)
   jsbundling-rails (>= 1.0.0)
   letter_opener_web (~> 2.0)
+  nokogiri (>= 1.13.9)
   pg (~> 1.4)
   pry-rails
   puma (~> 6)


### PR DESCRIPTION
Fixes multiple security advisories:

```
GHSA: GHSA-2qc6-mcvw-92cw
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-2qc6-mcvw-92cw Title: Update bundled libxml2 to v2.10.3 to resolve multiple CVEs Solution: upgrade to '>= 1.13.9'

GHSA: GHSA-2qc6-mcvw-92cw
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-2qc6-mcvw-92cw Title: Update bundled libxml2 to v2.10.3 to resolve multiple CVEs Solution: upgrade to '>= 1.13.9'

GHSA: GHSA-2qc6-mcvw-92cw
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-2qc6-mcvw-92cw Title: Update bundled libxml2 to v2.10.3 to resolve multiple CVEs Solution: upgrade to '>= 1.13.9'

GHSA: GHSA-2qc6-mcvw-92cw
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-2qc6-mcvw-92cw
Title: Update bundled libxml2 to v2.10.3 to resolve multiple CVEs
Solution: upgrade to '>= 1.13.9'
```