### PR TITLE
Bump rails-html-sanitizer to >= 1.4.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem "strong_migrations"
 gem "sidekiq"
 
 gem "nokogiri", ">= 1.13.9"
+gem "rails-html-sanitizer", ">= 1.4.4"
 
 group :development, :test do
   # Start debugger with binding.b [https://github.com/ruby/debug]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,8 +210,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
+    rails-html-sanitizer (1.4.4)
+      loofah (~> 2.19, >= 2.19.1)
     railties (7.0.4)
       actionpack (= 7.0.4)
       activesupport (= 7.0.4)
@@ -336,6 +336,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 6)
   rails (~> 7.0.4)
+  rails-html-sanitizer (>= 1.4.4)
   redis (~> 5.0)
   rspec-rails
   sidekiq


### PR DESCRIPTION
Fixes:

```
Name: rails-html-sanitizer
Version: 1.4.3
CVE: CVE-2022-23517
GHSA: GHSA-5x79-w82f-gw8w
Criticality: High
URL: https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-5x79-w82f-gw8w Title: Inefficient Regular Expression Complexity in rails-html-sanitizer Solution: upgrade to '>= 1.4.4'

Name: rails-html-sanitizer
Version: 1.4.3
CVE: CVE-2022-23518
GHSA: GHSA-mcvf-2q2m-x72m
Criticality: Medium
URL: https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-mcvf-2q2m-x72m Title: Improper neutralization of data URIs may allow XSS in rails-html-sanitizer Solution: upgrade to '>= 1.4.4'

Name: rails-html-sanitizer
Version: 1.4.3
CVE: CVE-2022-23519
GHSA: GHSA-9h9g-93gc-623h
Criticality: Unknown
URL: https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-9h9g-93gc-623h Title: Possible XSS vulnerability with certain configurations of rails-html-sanitizer Solution: upgrade to '>= 1.4.4'

Name: rails-html-sanitizer
Version: 1.4.3
CVE: CVE-2022-23520
GHSA: GHSA-rrfc-7g8p-99q8
Criticality: Unknown
URL: https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-rrfc-7g8p-99q8
Title: Possible XSS vulnerability with certain configurations of rails-html-sanitizer
Solution: upgrade to '>= 1.4.4'
```