### PR TITLE
Remove CodeClimate and update Readme with Ruby.CI badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,8 @@ jobs:
       - name: Zeitwerk eager load check
         run: bundle exec rails zeitwerk:check
 
-      - name: Setup Code Climate test-reporter
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-          ./cc-test-reporter before-build
-
       - name: RSpec
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
           DATABASE_URL: postgres://postgres:password@localhost:5432/test
           REDIS_URL: redis://localhost:6379/0
           RAILS_ENV: test
@@ -77,9 +70,3 @@ jobs:
         run: |
           bin/rails db:test:prepare
           bin/rake
-
-      - name: Publish code coverage
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        run: |
-          export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
-          ./cc-test-reporter after-build -r ${{secrets.CC_TEST_REPORTER_ID}}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Rails starter template
 
-[![Maintainability](https://api.codeclimate.com/v1/badges/1600dfceb82cea156f2f/maintainability)](https://codeclimate.com/github/peterberkenbosch/rails-starter-template/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/1600dfceb82cea156f2f/test_coverage)](https://codeclimate.com/github/peterberkenbosch/rails-starter-template/test_coverage)
-
 Opinionated Rails setup with the latest Rails, using PostgreSQL, TailwindCSS, Stimulus, Hotwire and RSpec.
 
 Using jsbundling-rails for Javascript, and TailwindCSS through PostCSS with cssbundling-rails. For easy loading of all Stimulus controllers

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Rails starter template
 
+![rspec](https://ruby.ci/badges/278d4d52-dcc5-4bd2-aa30-25d7845eeef1/rspec)
+![standard](https://ruby.ci/badges/278d4d52-dcc5-4bd2-aa30-25d7845eeef1/standard)
+![brakeman](https://ruby.ci/badges/278d4d52-dcc5-4bd2-aa30-25d7845eeef1/brakeman)
+![bundler_audit](https://ruby.ci/badges/278d4d52-dcc5-4bd2-aa30-25d7845eeef1/bundler_audit)
+
 Opinionated Rails setup with the latest Rails, using PostgreSQL, TailwindCSS, Stimulus, Hotwire and RSpec.
 
 Using jsbundling-rails for Javascript, and TailwindCSS through PostCSS with cssbundling-rails. For easy loading of all Stimulus controllers


### PR DESCRIPTION
Moving away from CodeClimate as this needs additional setup on the repositories using this app template.