### PR TITLE
Revert "Migrate to propshaft (#357)"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ ruby "~> 3"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem "rails", "~> 7.0.4"
 
-# The modern asset pipeline for Rails [https://github.com/rails/propshaft]
-gem "propshaft"
+# The traditional bundling and transpiling asset pipeline for Rails.
+gem "sprockets-rails", ">= 2.0.0"
 
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.4"
@@ -77,6 +77,4 @@ group :development do
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
   # gem 'rack-mini-profiler', '~> 2.0'
-
-  gem "listen"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,9 +145,6 @@ GEM
       letter_opener (~> 1.7)
       railties (>= 5.2)
       rexml
-    listen (3.8.0)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -184,11 +181,6 @@ GEM
     parser (3.2.0.0)
       ast (~> 2.4.1)
     pg (1.4.5)
-    propshaft (0.6.4)
-      actionpack (>= 7.0.0)
-      activesupport (>= 7.0.0)
-      rack
-      railties (>= 7.0.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -229,9 +221,6 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
-      ffi (~> 1.0)
     redis (5.0.5)
       redis-client (>= 0.9.0)
     redis-client (0.12.0)
@@ -284,10 +273,18 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    standard (1.22.0)
+    sprockets (4.2.0)
+      concurrent-ruby (~> 1.0)
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
+    standard (1.21.1)
       language_server-protocol (~> 3.17.0.2)
       rubocop (= 1.42.0)
       rubocop-performance (= 1.15.2)
+    standard (1.22.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     strong_migrations (1.4.1)
@@ -334,10 +331,8 @@ DEPENDENCIES
   jbuilder (~> 2.11)
   jsbundling-rails (>= 1.0.0)
   letter_opener_web (~> 2.0)
-  listen
   nokogiri (>= 1.13.9)
   pg (~> 1.4)
-  propshaft
   pry-rails
   puma (~> 6)
   rails (~> 7.0.4)
@@ -345,6 +340,7 @@ DEPENDENCIES
   rspec-rails
   sidekiq
   simplecov
+  sprockets-rails (>= 2.0.0)
   standard
   stimulus-rails (>= 1.0.0)
   strong_migrations

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 ![brakeman](https://ruby.ci/badges/278d4d52-dcc5-4bd2-aa30-25d7845eeef1/brakeman)
 ![bundler_audit](https://ruby.ci/badges/278d4d52-dcc5-4bd2-aa30-25d7845eeef1/bundler_audit)
 
-Opinionated Rails setup with the latest Rails, using PostgreSQL, TailwindCSS, Stimulus, Hotwire and RSpec.
+Opinionated Rails setup using Rails 7, PostgreSQL, TailwindCSS, Stimulus, Hotwire and RSpec.
 
-Using jsbundling-rails for Javascript, and TailwindCSS through PostCSS with cssbundling-rails. For easy loading of all Stimulus controllers
-we use esbuild-rails.
+We are bundling JavaScript and CSS through a Node-based setup with [`jsbundling-rails`](https://github.com/rails/jsbundling-rails) and [`cssbundling-rails`](https://github.com/rails/cssbundling-rails).
+
+If you want to run [`propshaft`](https://github.com/rails/propshaft) as the asset pipeline you can use this branch: https://github.com/peterberkenbosch/rails-starter-template/tree/propshaft. The main branch will be using Sprockets for the time being.
 
 You need the following installed:
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 ![brakeman](https://ruby.ci/badges/278d4d52-dcc5-4bd2-aa30-25d7845eeef1/brakeman)
 ![bundler_audit](https://ruby.ci/badges/278d4d52-dcc5-4bd2-aa30-25d7845eeef1/bundler_audit)
 
-Opinionated Rails setup using Rails 7, PostgreSQL, TailwindCSS, Stimulus, Hotwire and RSpec.
+Opinionated Rails setup with the latest Rails, using PostgreSQL, TailwindCSS, Stimulus, Hotwire and RSpec.
 
-We are bundling JavaScript and CSS through a Node-based setup with [`jsbundling-rails`](https://github.com/rails/jsbundling-rails) and [`cssbundling-rails`](https://github.com/rails/cssbundling-rails) and for the asset pipeline we are using [`propshaft`](https://github.com/rails/propshaft).
+Using jsbundling-rails for Javascript, and TailwindCSS through PostCSS with cssbundling-rails. For easy loading of all Stimulus controllers
+we use esbuild-rails.
 
 You need the following installed:
 

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link_tree ../images
+//= link_tree ../builds

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ require "action_mailbox/engine"
 require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
+require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,7 +68,4 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
-
-  # Propshaft improved performance using Listen
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end

--- a/config/initializers/asset_url_processor.rb
+++ b/config/initializers/asset_url_processor.rb
@@ -1,0 +1,11 @@
+class AssetUrlProcessor
+  def self.call(input)
+    context = input[:environment].context_class.new(input)
+    data = input[:data].gsub(/asset-url\(["']?(.+?)["']?\)/) do |_match|
+      "url(#{context.asset_path($1)})"
+    end
+    {data: data}
+  end
+end
+
+Sprockets.register_postprocessor "text/css", AssetUrlProcessor


### PR DESCRIPTION
This reverts commit bc443bfc0528c1e0bea840a947fdf08e8f23f239.

Since I use this repo setup for installing Solidus (among others) and Solidus is expecting sprockets to be present. 