### PR TITLE
Add a timeout for Cuprite driver.

### DIFF
--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -36,7 +36,8 @@ Capybara.register_driver(:better_cuprite) do |app|
     **{
       window_size: [1200, 800],
       browser_options: remote_chrome ? {"no-sandbox" => nil} : {},
-      inspector: true
+      inspector: true,
+      timeout: 60
     }.merge(remote_options)
   )
 end


### PR DESCRIPTION
Fixes this intermitted error on CI:

```
Ferrum::PendingConnectionsError:
       Request to http://fv-az196-639:44557/ reached server, but there are still pending connections: http://fv-az196-639:44557/
```